### PR TITLE
Fixed msgpack array_ref adaptor header which did include itself

### DIFF
--- a/include/rpc/msgpack/v1/adaptor/array_ref.hpp
+++ b/include/rpc/msgpack/v1/adaptor/array_ref.hpp
@@ -10,7 +10,6 @@
 #ifndef MSGPACK_V1_TYPE_ARRAY_REF_HPP
 #define MSGPACK_V1_TYPE_ARRAY_REF_HPP
 
-#include "rpc/msgpack/v1/adaptor/array_ref.hpp"
 #include "rpc/msgpack/adaptor/check_container_size.hpp"
 #include "rpc/msgpack/cpp_config.hpp"
 #include <cstring>


### PR DESCRIPTION
The header rpc/msgpack/v1/adaptor/array_ref.hpp did include itself.